### PR TITLE
feat(functionHistory): handle "Method" as well as "Function"

### DIFF
--- a/lua/tinygit/pickaxe.lua
+++ b/lua/tinygit/pickaxe.lua
@@ -281,7 +281,7 @@ function M.functionHistory()
 		vim.lsp.buf.document_symbol {
 			on_list = function(response)
 				local funcsObjs = vim.tbl_filter(
-					function(item) return item.kind == "Function" end,
+					function(item) return item.kind == "Function" or item.kind == "Method" end,
 					response.items
 				)
 				if #funcsObjs == 0 then
@@ -290,7 +290,13 @@ function M.functionHistory()
 				end
 
 				local funcNames = vim.tbl_map(
-					function(item) return item.text:gsub("^%[Function%] ", "") end,
+					function(item) 
+						if item.kind == "Function" then
+							return item.text:gsub("^%[Function%] ", "") 
+						elseif item.kind == "Method" then
+							return item.text:match("%[Method%]%s+([^%(]+)")
+						end
+					end,
 					funcsObjs
 				)
 				vim.ui.select(


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the readme.
- [x] Used conventional commits keywords.

## Changes
I was trying to get `functionHistory` to work with Swift. I [modified my git-attributes](https://juripakaste.fi/swift-git-attributes/) so `git log -L :func:file` works with Swift, but invoking `functionHistory()` presented an empty list. Turns out Swift functions have kind "Method" instead of "Function", so I added that to the filter.

In addition, for Method I had to strip off everything after the initial function name (`foo(bar:baz:)` → `foo`), otherwise `git log ...` would fail.

This change should be transparent to the user, so I didn't update the README.