### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ operations.
 
 ## Installation
 
-Install the Treesitter parser for git filetypes: `TSInstall gitcommit gitrebase`
+Install the Treesitter parser for git filetypes: `TSInstall gitcommit git_rebase`
 
 ```lua
 -- lazy.nvim
 {
 	"chrisgrieser/nvim-tinygit",
-	ft = { "gitrebase", "gitcommit" }, -- so ftplugins are loaded
+	ft = { "git_rebase", "gitcommit" }, -- so ftplugins are loaded
 	dependencies = {
 		"stevearc/dressing.nvim",
 		"nvim-telescope/telescope.nvim", -- either telescope or fzf-lua


### PR DESCRIPTION
nvim-treesitter language for git rebase is currently `git_rebase`

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  README.md (the `.txt` file is auto-generated and does not need to be modified).
- [x] Used conventional commits keywords.
