### PR TITLE
feat: interactiveStaging multiselect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ use {
   full file. It is roughly comparable to `git add -p`.
 - Use `<Space>` to (un)stage the hunk, `<CR>` to go to the hunk, or `<C-r` to
   reset the hunk (mappings customizable). Your regular `telescope` mappings also
-  apply.
+  apply. Staging and resets support Telescope multi selections.
 - The size of the hunks is determined by the setting `staging.contextSize`.
   Larger context size is going to "merge" changes that are close to one another
   into one hunk. (As such, the hunks displayed are not 1:1 the same as the hunks

--- a/lua/tinygit/commands/staging.lua
+++ b/lua/tinygit/commands/staging.lua
@@ -287,19 +287,23 @@ local function telescopePickHunk(hunks)
 				end, { desc = "Staging Toggle" })
 
 				map({ "n", "i" }, opts.keymaps.resetHunk, function()
-					local entry = actionState.get_selected_entry()
-					local hunk = entry.value
+					local multi = picker:get_multi_selection()
+					local selections = next(multi) and multi or { actionState.get_selected_entry() }
+					for i, entry in pairs(selections) do
+						local hunk = entry.value
 
-					-- a staged hunk cannot be reset, so we unstage it first
-					if hunk.alreadyStaged then
-						local success1 = applyPatch(hunk, "toggle")
-						if not success1 then return end
-						hunk.alreadyStaged = false
+						-- a staged hunk cannot be reset, so we unstage it first
+						if hunk.alreadyStaged then
+							local success1 = applyPatch(hunk, "toggle")
+							if not success1 then return end
+							hunk.alreadyStaged = false
+						end
+
+						local success2 = applyPatch(hunk, "reset")
+						if not success2 then return end
+						-- remove from list as not a hunk anymore
+						table.remove(hunks, entry.index - i + 1)
 					end
-
-					local success2 = applyPatch(hunk, "reset")
-					if not success2 then return end
-					table.remove(hunks, entry.index) -- remove from list as not a hunk anymore
 					refreshPicker()
 				end, { desc = "Reset Hunk" })
 

--- a/lua/tinygit/commands/staging.lua
+++ b/lua/tinygit/commands/staging.lua
@@ -289,6 +289,7 @@ local function telescopePickHunk(hunks)
 				map({ "n", "i" }, opts.keymaps.resetHunk, function()
 					local multi = picker:get_multi_selection()
 					local selections = next(multi) and multi or { actionState.get_selected_entry() }
+
 					for i, entry in pairs(selections) do
 						local hunk = entry.value
 
@@ -304,7 +305,12 @@ local function telescopePickHunk(hunks)
 						-- remove from list as not a hunk anymore
 						table.remove(hunks, entry.index - i + 1)
 					end
-					refreshPicker()
+
+					if next(hunks) then
+						refreshPicker()
+					else
+						actions.close(prompt_bufnr)
+					end
 				end, { desc = "Reset Hunk" })
 
 				return true -- keep default mappings


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).

## Changes

Toggle the staging status of hunks selected with Telescope multi select

![staging](https://github.com/user-attachments/assets/43db6c38-1e32-4f34-801c-f1300243ad29)

Reset multiple hunks with Telescope multiselect. If no hunks remain, close interactiveStaging picker (gif doesn't reflect this feature)

![resetting](https://github.com/user-attachments/assets/7a287c3f-4a37-4474-bdfc-979584df6ab0)
