### PR TITLE
improv: bail if nothing is staged and `stageAllIfNothingStaged` is set to `false`

### DIFF
--- a/lua/tinygit/commands/commit-and-amend.lua
+++ b/lua/tinygit/commands/commit-and-amend.lua
@@ -416,10 +416,17 @@ function M.amendNoEdit(opts)
 	opts = vim.tbl_deep_extend("force", defaultOpts, opts or {})
 
 	-- stage
-	local doStageAllChanges = opts.stageAllIfNothingStaged and hasNoStagedChanges()
-	if doStageAllChanges then
-		local result = vim.system({ "git", "add", "--all" }):wait()
-		if u.nonZeroExit(result) then return end
+	local doStageAllChanges = false
+	local nothingStaged = hasNoStagedChanges()
+	if nothingStaged then
+		if opts.stageAllIfNothingStaged then
+			doStageAllChanges = true
+			local result = vim.system({ "git", "add", "--all" }):wait()
+			if u.nonZeroExit(result) then return end
+		else
+			u.notify("Nothing staged. Aborting.", "warn")
+			return
+		end
 	end
 
 	-- commit


### PR DESCRIPTION
There's no point in proceeding if nothing is staged and `stageAllIfNothingStaged` is set to `false`. Also, since it is most likely a mistake, it would be good to raise awareness.

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
