### PR TITLE
improv: don't trim long commit message

### DIFF
--- a/lua/tinygit/commands/commit-and-amend.lua
+++ b/lua/tinygit/commands/commit-and-amend.lua
@@ -48,8 +48,7 @@ local function processCommitMsg(commitMsg)
 
 	if #commitMsg > commitMaxLen then
 		u.notify("Commit Message too long.", "warn")
-		local shortenedMsg = commitMsg:sub(1, commitMaxLen)
-		return false, shortenedMsg
+		return false, commitMsg
 	elseif commitMsg == "" then
 		u.notify("Commit Message empty.", "warn")
 		return false, ""


### PR DESCRIPTION
When I hit this error, I never want to use trimmed message as is - I usually reword it to shorten to the required length. So I propose to keep user input untouched so they don't need to retype the trimmed tail.

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
