### PR TITLE
feat: add a config option to show file paths when staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ require("tinygit").setup {
 			resetHunk = "<C-r>",
 		},
 		moveToNextHunkOnStagingToggle = false,
+		showFilePaths = false,
 
 		-- accepts the common telescope picker config
 		telescopeOpts = {

--- a/lua/tinygit/commands/stage/telescope.lua
+++ b/lua/tinygit/commands/stage/telescope.lua
@@ -33,7 +33,7 @@ local function newFinder(hunks)
 				local h = _entry.value
 				local changeWithoutHunk = h.lnum == -1
 
-				local name = vim.fs.basename(h.relPath)
+				local name = conf.showFilePaths and h.relPath or vim.fs.basename(h.relPath)
 				local added = h.added > 0 and (" +" .. h.added) or ""
 				local del = h.removed > 0 and (" -" .. h.removed) or ""
 				local location = ""

--- a/lua/tinygit/config.lua
+++ b/lua/tinygit/config.lua
@@ -23,6 +23,7 @@ local defaultConfig = {
 			resetHunk = "<C-r>",
 		},
 		moveToNextHunkOnStagingToggle = false,
+		showFilePaths = false,
 
 		-- accepts the common telescope picker config
 		telescopeOpts = {


### PR DESCRIPTION
## Problem statement
When staging, I want to be able to distinguish files by looking at the file paths. In Svelte, multiple files have the same name so the only way to tell them apart is by seeing which directory they're in.

## Proposed solution
Add a configurable option to show file paths (disabled by default)

## AI usage disclosure
No AI used

## Checklist
- [x] Variable names follow `camelCase` convention.
- [x] All AI-generated code has been reviewed by a human.
- [x] The `README.md` has been updated for any new or modified functionality
  (the `.txt` file is auto-generated and does not need to be modified).
