### PR TITLE
fix: parse filepath that contains b/

### DIFF
--- a/lua/tinygit/commands/stage.lua
+++ b/lua/tinygit/commands/stage.lua
@@ -65,7 +65,7 @@ local function getHunksFromDiffOutput(diffCmdStdout, diffIsOfStaged)
 		local diffLines = vim.split(file, "\n")
 		local changesInFile, diffHeaderLines, fileMode, _ = splitOffDiffHeader(diffLines)
 		local diffHeader = table.concat(diffHeaderLines, "\n")
-		local relPath = diffHeaderLines[1]:match("b/(.+)")
+		local relPath = diffHeaderLines[1]:match("a/.+ b/(.+)")
 		assert(relPath, "Failed to parse diff header:\n" .. table.concat(diffHeaderLines, "\n"))
 		local absPath = gitroot .. "/" .. relPath
 


### PR DESCRIPTION
## Problem statement
Filepaths that contain `b/` are not parsed correctly from the diff output. For example, if the path is `web/file.txt`, then `diffHeaderLines[1]` will be `diff --git a/web/file.txt b/web/file.txt`. Since `b/` is a substring of `web/file.txt`, the `b/(.+)` lua pattern will match `file.txt b/web/file.txt` instead of `web/file.txt`. 

## Proposed solution
Fix the lua pattern so that it ignores any `b/` substring in the filepath starting with `a/`.

## AI usage disclosure
No AI

## Checklist
- [x] Variable names follow `camelCase` convention.
- [x] All AI-generated code has been reviewed by a human.
- [x] The `README.md` has been updated for any new or modified functionality
  (the `.txt` file is auto-generated and does not need to be modified).
